### PR TITLE
Parse escaped quotes in commands properly

### DIFF
--- a/__tests__/parsers.test.ts
+++ b/__tests__/parsers.test.ts
@@ -280,20 +280,19 @@ describe("parseFunctionCall", () => {
     };
     expect(output).toEqual(expectedOutput);
   });
-  // TODO: This fails may cause an issue in the future
-  // it("string has escaped quote in it", () => {
-  //   const str = `set_coordinates(x=3.14, placeName="The Moon,\\" sun ", y=0.98)`;
-  //   const output = parseFunctionCall(str);
-  //   const expectedOutput = {
-  //     name: "set_coordinates",
-  //     args: {
-  //       x: 3.14,
-  //       y: 0.98,
-  //       placeName: 'The Moon," sun ',
-  //     },
-  //   };
-  //   expect(output).toEqual(expectedOutput);
-  // });
+  it("string has escaped quote in it", () => {
+    const str = `set_coordinates(x=3.14, placeName="The Moon,\\" sun ", y=0.98)`;
+    const output = parseFunctionCall(str);
+    const expectedOutput = {
+      name: "set_coordinates",
+      args: {
+        x: 3.14,
+        y: 0.98,
+        placeName: 'The Moon," sun ',
+      },
+    };
+    expect(output).toEqual(expectedOutput);
+  });
   it("returns function with no arguments when none are provided", () => {
     const str = `do_something()`;
     const output = parseFunctionCall(str);
@@ -349,5 +348,29 @@ describe("parseFunctionCall", () => {
       },
     };
     expect(output).toEqual(expectedOutput);
+  });
+  it("parse escaped quotes properly", () => {
+    const out = parseFunctionCall(
+      `search_filings(query="formType:\\"S-4\\" AND NOT formType:(\\"4/A\\" OR \\"S-4 POS\\")", ticker="AAPL")`,
+    );
+    expect(out).toStrictEqual({
+      name: "search_filings",
+      args: {
+        query: 'formType:"S-4" AND NOT formType:("4/A" OR "S-4 POS")',
+        ticker: "AAPL",
+      },
+    });
+  });
+  it("parse escaped quotes properly - single quotes", () => {
+    const out = parseFunctionCall(
+      `search_filings(query='formType:"S-4" AND NOT formType:("4/A" OR "S-4 POS")', ticker="AAPL")`,
+    );
+    expect(out).toStrictEqual({
+      name: "search_filings",
+      args: {
+        query: 'formType:"S-4" AND NOT formType:("4/A" OR "S-4 POS")',
+        ticker: "AAPL",
+      },
+    });
   });
 });

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nextjs",
       "version": "0.1.0",
       "dependencies": {
-        "@superflows/chat-ui-react": "^1.2.3",
+        "@superflows/chat-ui-react": "^1.2.5",
         "@types/node": "20.4.6",
         "@types/react": "18.2.18",
         "@types/react-dom": "18.2.7",
@@ -284,9 +284,9 @@
       }
     },
     "node_modules/@superflows/chat-ui-react": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@superflows/chat-ui-react/-/chat-ui-react-1.2.3.tgz",
-      "integrity": "sha512-rifU2dklVR7itY5eB8TPLvj7UyA6HAuPdqp52N6bTkY9H+IeLGBnW0kaOdtOhQuJILwg0vsq4E4XNeVXsI8SHw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@superflows/chat-ui-react/-/chat-ui-react-1.2.5.tgz",
+      "integrity": "sha512-IYkYAxZP+64DOeYOcjtg0mU3UHuoK532OCtooIAvANiPtw624VnT9fAoA2tjoIwkHfGN9IGXtLVXk/51nStdkA==",
       "dependencies": {
         "@headlessui/react": "1.4",
         "@heroicons/react": "^2.0.18",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@superflows/chat-ui-react": "^1.2.3",
+    "@superflows/chat-ui-react": "^1.2.5",
     "@types/node": "20.4.6",
     "@types/react": "18.2.18",
     "@types/react-dom": "18.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@superflows/chat-ui-react",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@superflows/chat-ui-react",
-      "version": "1.2.3",
+      "version": "1.2.5",
       "dependencies": {
         "@headlessui/react": "1.4",
         "@heroicons/react": "^2.0.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superflows/chat-ui-react",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "main": "dist/index.js",
   "devDependencies": {
     "@heroicons/react": "^2.0.18",

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -133,7 +133,20 @@ export function getLastSectionName(gptString: string): string {
 }
 
 export function parseFunctionCall(text: string): FunctionCall {
+  // Below regex captures the function name and arguments
+  // (\w+) matches the function name (any non whitespace characters)
+  // \( matches the opening bracket
+  // (.*) matches everything inside the brackets
+  // \) matches the closing bracket
   const functionCallRegex = /(\w+)\((.*)\)/;
+  // Below regex captures the arguments inside the function call brackets, one by one
+  // ([^,\s]+?) matches the argument name
+  // ({.*?}|'.*?'|".*?([^\\])"|\[.*?\]|[^,]*) matches the argument value
+  //   {.*?} matches an object
+  //   '.*?' matches a string wrapped in single quotes
+  //   ".*?([^\\])" matches a string wrapped in double quotes
+  //   \[.*?\] matches an array
+  //   [^,]* matches anything that is not a comma (e.g. string without quotes/number/boolean)
   const argumentRegex = /([^,\s]+?)=({.*?}|'.*?'|".*?([^\\])"|\[.*?\]|[^,]*)/g;
 
   const functionCallMatch = text.match(functionCallRegex);


### PR DESCRIPTION
Fixes the below (`query` parameter has been cut short)

![Screenshot from 2023-10-01 21-43-11](https://github.com/Superflows-AI/chat-ui/assets/33871096/4dd2055e-5547-4fed-bc1a-37bff595ca1d)
