### PR TITLE
removeSingleKeyNodes -> processObjectForDisplay

### DIFF
--- a/__tests__/processObjectForDisplay.test.ts
+++ b/__tests__/processObjectForDisplay.test.ts
@@ -1,33 +1,33 @@
 import { describe, expect, it } from "@jest/globals";
-import { removeSingleKeyNodes } from "../src/lib/utils";
+import { processObjectForDisplay } from "../src/lib/utils";
 
 describe("remove single key nodes", () => {
   it("Handles empty object", () => {
     const data = {};
     const expected = {};
 
-    expect(removeSingleKeyNodes(data)).toEqual(expected);
+    expect(processObjectForDisplay(data)).toEqual(expected);
   });
 
   it("array returns same array", () => {
     const data = [1, 2, 3];
     const expected = [1, 2, 3];
 
-    const output = removeSingleKeyNodes(data);
+    const output = processObjectForDisplay(data);
     expect(output).toEqual(expected);
   });
 
   it("special case single array", () => {
     const data = { oldGregg: [1, 2, 3] };
     const expected = [1, 2, 3];
-    const output = removeSingleKeyNodes(data);
+    const output = processObjectForDisplay(data);
     expect(output).toEqual(expected);
   });
   it("nested special case", () => {
     const data = { root: { branch: { leaf: [1, 2, 3] } } };
     const expected = [1, 2, 3];
 
-    expect(removeSingleKeyNodes(data)).toEqual(expected);
+    expect(processObjectForDisplay(data)).toEqual(expected);
   });
   it("more complex nested special case", () => {
     const data = {
@@ -44,7 +44,7 @@ describe("remove single key nodes", () => {
       { nice: 2, nested: { boy: 3 } },
     ];
 
-    const output = removeSingleKeyNodes(data);
+    const output = processObjectForDisplay(data);
     expect(output).toEqual(expected);
   });
 
@@ -53,7 +53,7 @@ describe("remove single key nodes", () => {
       { a: 1, b: 2, c: 3 },
       { a: 4, b: 5, c: 6 },
     ];
-    const output = removeSingleKeyNodes(data);
+    const output = processObjectForDisplay(data);
     expect(output).toEqual(data);
   });
 
@@ -71,7 +71,7 @@ describe("remove single key nodes", () => {
       "umbrella -> theHitcher": "put you in the picture",
       "umbrella -> tony -> harrison": "outrage",
     };
-    const output = removeSingleKeyNodes(data);
+    const output = processObjectForDisplay(data);
     expect(output).toEqual(expected);
   });
 
@@ -90,7 +90,7 @@ describe("remove single key nodes", () => {
       "outer -> middle2": "value2",
     };
 
-    expect(removeSingleKeyNodes(data)).toEqual(expected);
+    expect(processObjectForDisplay(data)).toEqual(expected);
   });
 
   it("Does not lose data for deeply nested structures", () => {
@@ -132,7 +132,7 @@ describe("remove single key nodes", () => {
       ],
     };
 
-    expect(removeSingleKeyNodes(data)).toEqual(expected);
+    expect(processObjectForDisplay(data)).toEqual(expected);
   });
 
   it("doesnt mutate original data", () => {
@@ -152,8 +152,24 @@ describe("remove single key nodes", () => {
 
     const originalData = JSON.parse(JSON.stringify(data));
 
-    const result = removeSingleKeyNodes(data);
+    const result = processObjectForDisplay(data);
     expect(data).toEqual(originalData);
     expect(result).not.toBe(data);
+  });
+
+  it("Array of single key not changed", () => {
+    const data = [
+      { make: "Alfa Romeo" },
+      { make: "Ferrari" },
+      { make: "Dodge" },
+      { make: "Subaru" },
+      { make: "Toyota" },
+      { make: "Volkswagen" },
+      { make: "Volvo" },
+      { make: "Audi" },
+    ];
+
+    const result = processObjectForDisplay(data);
+    expect(result).toEqual(data);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superflows/chat-ui-react",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "main": "dist/index.js",
   "devDependencies": {
     "@heroicons/react": "^2.0.18",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -47,7 +47,7 @@ export function convertToMarkdownTable(
   }
 
   // Do this here so we get the correct caption
-  data = removeSingleKeyNodes(data);
+  data = processObjectForDisplay(data);
 
   if (Array.isArray(data)) {
     // Assume all elements have the same type
@@ -163,12 +163,15 @@ export function removeUUIDs(
   }
 }
 
-export function removeSingleKeyNodes(
+export function processObjectForDisplay(
   data: Record<string, any> | any[],
   fieldName: string[] = [],
 ): Record<string, any> | any[] {
-  // Recursively removes nodes with a single key where the value of the node
-  // is an object
+  /**
+   * Processes an arbitrary object for display in a table
+   * Returns a flattened form of the object, with nested keys separated by " -> "
+   * also recursively removes nodes with a single key where the value of the node
+   */
 
   // Handle special case where parent object is e.g. {a: [1,2,3]}, should return [1,2,3]
   if (!Array.isArray(data)) {
@@ -181,7 +184,11 @@ export function removeSingleKeyNodes(
   if (Array.isArray(data)) {
     const result: any[] = [];
     data.forEach((item) => {
-      result.push(removeSingleKeyNodes(item, fieldName));
+      if (typeof item === "object" && Object.keys(item).length > 1) {
+        result.push(processObjectForDisplay(item, fieldName));
+      } else {
+        result.push(item);
+      }
     });
     return result;
   }


### PR DESCRIPTION
Renamed removeSingleKeyNodes as this function does more than removing nodes. Added a docstring. Fixed a bug for arrays of single key objects.