### PR TITLE
Allow forgetting brackets in function calls, assuming no args

### DIFF
--- a/__tests__/parsers.test.ts
+++ b/__tests__/parsers.test.ts
@@ -225,8 +225,11 @@ describe("Parse output", () => {
       "- Inform the user about the retrieved information.",
     );
     expect(output.tellUser).toBe("");
-    expect(output.commands).toStrictEqual([]);
-    expect(output.completed).toBe(true);
+    expect(output.commands).toStrictEqual([{
+      name: "function_ca",
+      args: {},
+    }]);
+    expect(output.completed).toBe(false);
   });
   it("tell user mistakenly put under commands", () => {
     const output = parseOutput(
@@ -469,6 +472,13 @@ describe("parseFunctionCall", () => {
         query: 'formType:"S-4" AND NOT formType:("4/A" OR "S-4 POS")',
         ticker: "AAPL",
       },
+    });
+  });
+  it("parse okay when brackets forgotten", () => {
+    const out = parseFunctionCall(`list_users`);
+    expect(out).toStrictEqual({
+      name: "list_users",
+      args: {},
     });
   });
 });

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -140,7 +140,9 @@ export function parseFunctionCall(text: string): FunctionCall {
   // \( matches the opening bracket
   // (.*) matches everything inside the brackets
   // \) matches the closing bracket
-  const functionCallRegex = /(\w+)\((.*)\)/;
+  // |(\w+) matches the function name if the brackets were forgotten
+  //  (common on fine-tuned 3.5)
+  const functionCallRegex = /^((\w+)\((.*)\)|(\w+))$/;
   // Below regex captures the arguments inside the function call brackets, one by one
   // ([^,\s]+?) matches the argument name
   // ({.*?}|'.*?'|".*?([^\\])"|\[.*?\]|[^,]*) matches the argument value
@@ -156,8 +158,8 @@ export function parseFunctionCall(text: string): FunctionCall {
     throw new Error("Invalid function call format: " + text);
   }
 
-  const name = functionCallMatch[1];
-  const argsText = functionCallMatch[2];
+  const name = functionCallMatch[2] || functionCallMatch[4];
+  const argsText = functionCallMatch[3] ?? "";
   let argMatch;
   const args = {};
 


### PR DESCRIPTION
This change is because, especially when outputting function calls where there are no arguments needed, fine-tuned 3.5 sometimes forgets brackets.